### PR TITLE
Added CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ matrix:
         env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54
       - <<: *linux
         env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
       - <<: *osx
         osx_image: xcode7.3
         env: CONAN_APPLE_CLANG_VERSIONS=7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+
+env:
+   global:
+     - CONAN_REFERENCE: "ZenGitHub/1.0"
+     - CONAN_USERNAME: "jonico"
+     - CONAN_LOGIN_USERNAME: "jonico"
+     - CONAN_CHANNEL: "testing"
+     - CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
+     - CONAN_STABLE_BRANCH_PATTERN: "release/*"
+
+linux: &linux
+   os: linux
+   sudo: required
+   language: python
+   python: "3.6"
+   services:
+     - docker
+osx: &osx
+   os: osx
+   language: generic
+matrix:
+   include:
+
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=lasote/conangcc49
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
+      - <<: *osx
+        osx_image: xcode7.3
+        env: CONAN_APPLE_CLANG_VERSIONS=7.3
+      - <<: *osx
+        osx_image: xcode8.2
+        env: CONAN_APPLE_CLANG_VERSIONS=8.0
+      - <<: *osx
+        osx_image: xcode8.3
+        env: CONAN_APPLE_CLANG_VERSIONS=8.1
+
+install:
+  - chmod +x .travis/install.sh
+  - ./.travis/install.sh
+
+script:
+  - chmod +x .travis/run.sh
+  - ./.travis/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
      - CONAN_LOGIN_USERNAME: "jonico"
      - CONAN_CHANNEL: "testing"
      #- CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
-     - CONAN_UPLOAD: https://api.bintray.com/conan/conan-community/conan
+     - CONAN_UPLOAD: "https://server.conan.io"
      - CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
 linux: &linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
      - CONAN_USERNAME: "jonico"
      - CONAN_LOGIN_USERNAME: "jonico"
      - CONAN_CHANNEL: "testing"
-     #- CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
-     - CONAN_UPLOAD: "https://server.conan.io"
+     - CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
+     # CONAN_UPLOAD: "https://server.conan.io"
      - CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
 linux: &linux
@@ -34,7 +34,7 @@ matrix:
       - <<: *osx
         osx_image: xcode8.2
         env: CONAN_APPLE_CLANG_VERSIONS=8.0
-      
+
 install:
   - chmod +x .travis/install.sh
   - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,7 @@ matrix:
       - <<: *osx
         osx_image: xcode8.2
         env: CONAN_APPLE_CLANG_VERSIONS=8.0
-      - <<: *osx
-        osx_image: xcode8.3
-        env: CONAN_APPLE_CLANG_VERSIONS=8.1
-
+      
 install:
   - chmod +x .travis/install.sh
   - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ env:
      - CONAN_USERNAME: "jonico"
      - CONAN_LOGIN_USERNAME: "jonico"
      - CONAN_CHANNEL: "testing"
-     - CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
+     #- CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
+     - CONAN_UPLOAD: https://api.bintray.com/conan/conan-community/conan
      - CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
 linux: &linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
      - CONAN_LOGIN_USERNAME: "jonico"
      - CONAN_CHANNEL: "testing"
      - CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
-     # CONAN_UPLOAD: "https://server.conan.io"
      - CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
 linux: &linux

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    brew install cmake || true
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    pyenv install 2.7.10
+    pyenv virtualenv 2.7.10 conan
+    pyenv rehash
+    pyenv activate conan
+fi
+
+pip install conan --upgrade
+pip install conan_package_tools
+
+conan user

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+    pyenv activate conan
+fi
+
+python build.py

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/jonico/libzengithub.svg)](https://travis-ci.org/jonico/libzengithub)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/jonico/libzengithub)](https://ci.appveyor.com/project/jonico/libzengithub)
+
 # libzengithub - an example how to build portable [conan.io](https://www.conan.io/) C/C++ packages
 
 ```libzengithub``` prints out a random [Zen of Github](http://ben.balter.com/2015/08/12/the-zen-of-github/) whenever you call its only function.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,12 +15,14 @@ environment:
 
     matrix:
         #- MINGW_CONFIGURATIONS: "4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix, 4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix"
+        # commented out because OpenSSH package for libcurl is missing
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
         #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
         #  CONAN_VISUAL_VERSIONS: 15
+        # commented out because libcurl does not have VS 2017 builds
 
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,13 +15,13 @@ environment:
     CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
     matrix:
-        - MINGW_CONFIGURATIONS: "4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix, 4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix"
+        #- MINGW_CONFIGURATIONS: "4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix, 4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix"
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
+        #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+        #  CONAN_VISUAL_VERSIONS: 15
 
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+build: false
+
+environment:
+    PYTHON: "C:\\Python27"
+    PYTHON_VERSION: "2.7.8"
+    PYTHON_ARCH: "32"
+
+    CONAN_REFERENCE: "zlib/1.2.8"
+    CONAN_USERNAME: "conan"
+    CONAN_LOGIN_USERNAME: "lasote"
+    CONAN_CHANNEL: "stable"
+    VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"
+    CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
+    CONAN_STABLE_BRANCH_PATTERN: "release/*"
+
+    matrix:
+        - MINGW_CONFIGURATIONS: "4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix, 4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix"
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+
+install:
+  - set PATH=%PATH%;%PYTHON%/Scripts/
+  - pip.exe install conan --upgrade
+  - pip.exe install conan_package_tools
+  - conan user # It creates the conan data directory
+
+test_script:
+  - python build.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ environment:
     PYTHON_VERSION: "2.7.8"
     PYTHON_ARCH: "32"
 
-    CONAN_REFERENCE: "zlib/1.2.8"
+    CONAN_REFERENCE: "ZenGitHub/1.0"
     CONAN_USERNAME: "conan"
-    CONAN_LOGIN_USERNAME: "lasote"
+    CONAN_LOGIN_USERNAME: "jonico"
     CONAN_CHANNEL: "stable"
     VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"
     CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     CONAN_CHANNEL: "stable"
     VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"
     # CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
-    CONAN_UPLOAD: "https://api.bintray.com/conan/conan-community/conan"
+    CONAN_UPLOAD: "https://server.conan.io"
     CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,8 @@ environment:
     CONAN_LOGIN_USERNAME: "jonico"
     CONAN_CHANNEL: "stable"
     VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"
-    CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
+    # CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
+    CONAN_UPLOAD: "https://api.bintray.com/conan/conan-community/conan"
     CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,7 @@ environment:
     CONAN_LOGIN_USERNAME: "jonico"
     CONAN_CHANNEL: "stable"
     VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"
-    # CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
-    CONAN_UPLOAD: "https://server.conan.io"
+    CONAN_UPLOAD: "https://api.bintray.com/conan/conan-jonico/libzengithub"
     CONAN_STABLE_BRANCH_PATTERN: "release/*"
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     PYTHON_ARCH: "32"
 
     CONAN_REFERENCE: "ZenGitHub/1.0"
-    CONAN_USERNAME: "conan"
+    CONAN_USERNAME: "jonico"
     CONAN_LOGIN_USERNAME: "jonico"
     CONAN_CHANNEL: "stable"
     VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\Common7\\Tools\\"

--- a/build.py
+++ b/build.py
@@ -4,5 +4,5 @@ import platform
 
 if __name__ == "__main__":
     builder = ConanMultiPackager()
-    builder.add_common_builds(pure_c=True)
+    builder.add_common_builds(pure_c=True, shared_option_name="ZenGitHub:shared")
     builder.run()

--- a/build.py
+++ b/build.py
@@ -1,0 +1,8 @@
+from conan.packager import ConanMultiPackager
+import platform
+
+
+if __name__ == "__main__":
+    builder = ConanMultiPackager()
+    builder.add_common_builds(pure_c=True)
+    builder.run()

--- a/build.py
+++ b/build.py
@@ -5,4 +5,26 @@ import platform
 if __name__ == "__main__":
     builder = ConanMultiPackager()
     builder.add_common_builds(pure_c=True, shared_option_name="ZenGitHub:shared")
+    accepted_builds = []
+    if platform.system() == "Linux":
+        for build in builder.builds:
+            if build[0]["arch"] != "x86":
+                accepted_builds.append([build[0], build[1]])
+        builder.builds = accepted_builds
+
+    if platform.system() == "Darwin":
+        for build in builder.builds:
+            if not build[0]["arch"] == "x86":
+                accepted_builds.append([build[0], build[1]])
+
+        builder.builds = accepted_builds
+        for compiler in builder.apple_clang_versions:
+            builder.add({"compiler": "apple-clang", "compiler.version": compiler,
+                         "arch": "x86_64", "build_type": "Release"}, {"libcurl:shared": False,
+                                                                  "libcurl:darwin_ssl": False,
+                                                                  "libcurl:custom_cacert": True})
+            builder.add({"compiler": "apple-clang", "compiler.version": compiler,
+                         "arch": "x86_64", "build_type": "Debug"}, {"libcurl:shared": False,
+                                                                  "libcurl:darwin_ssl": False,
+                                                           "libcurl:custom_cacert": True})
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ class ZenGithubConan(ConanFile):
     default_options = "shared=False"
     generators = "cmake"
     exports_sources = "zengithub/*"
-    requires = "libcurl/7.50.3@lasote/stable", "zlib/1.2.8@conan/stable"
+    requires = "libcurl/7.50.3@lasote/stable", "zlib/1.2.8@conan/stable", "OpenSSL/1.0.2i@conan/stable"
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ class ZenGithubConan(ConanFile):
     default_options = "shared=False"
     generators = "cmake"
     exports_sources = "zengithub/*"
-    requires = "libcurl/7.50.3@lasote/stable", "zlib/1.2.8@conan/stable", "OpenSSL/1.0.2l@conan/stable"
+    requires = "libcurl/7.50.3@lasote/stable", "zlib/1.2.8@conan/stable"
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ class ZenGithubConan(ConanFile):
     default_options = "shared=False"
     generators = "cmake"
     exports_sources = "zengithub/*"
-    requires = "libcurl/7.50.3@lasote/stable", "zlib/1.2.8@conan/stable", "OpenSSL/1.0.2i@conan/stable"
+    requires = "libcurl/7.50.3@lasote/stable", "zlib/1.2.8@conan/stable", "OpenSSL/1.0.2l@conan/stable"
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,7 +12,7 @@ class ZenGithubConan(ConanFile):
     default_options = "shared=False"
     generators = "cmake"
     exports_sources = "zengithub/*"
-    requires = "libcurl/7.50.3@lasote/stable"
+    requires = "libcurl/7.50.3@lasote/stable", "zlib/1.2.8@conan/stable"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
Followed https://github.com/conan-io/conan-package-tools to provide a range of different operating system, compiler version, debug and release builds for this library.

Using Travis CI for Linux and Mac builds and AppVeyor for Windows builds.

Had to exclude certain platforms as ```libcurl``` and OpenSSL packages were not built for all possible mutations. Packages are uploaded to https://api.bintray.com/conan/conan-jonico/libzengithub

The result is awesome:

```
conan search ZenGitHub/1.0@jonico/stable -r=conan --table build_matrix.html
open build_matrix.html
```

![image](https://user-images.githubusercontent.com/1872314/28708619-246fbe24-737d-11e7-92f1-ac8d5e149756.png)
